### PR TITLE
Port to servant & servant-docs 0.4

### DIFF
--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -57,7 +57,7 @@ library
   other-extensions:    OverloadedStrings
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.8, http-media >=0.6 && <0.7, lens >=4.9 && <4.10, pandoc-types >=1.12 && <1.13, servant-docs >=0.3 && <4, unordered-containers >=0.2 && <0.3, text >=1.2 && <1.3, bytestring >=0.10 && <0.11
+  build-depends:       base >=4.7 && <4.8, http-media >=0.6 && <0.7, lens >=4.9 && <4.10, pandoc-types >=1.12 && <1.13, servant-docs >=0.4 && <0.5, unordered-containers >=0.2 && <0.3, text >=1.2 && <1.3, bytestring >=0.10 && <0.11
 
   -- Directories containing source files.
   hs-source-dirs:      src

--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -57,7 +57,7 @@ library
   other-extensions:    OverloadedStrings
 
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.7 && <4.8, pandoc-types >=1.12 && <1.13, servant-docs >=0.3 && <0.4, unordered-containers >=0.2 && <0.3, text >=1.2 && <1.3, bytestring >=0.10 && <0.11
+  build-depends:       base >=4.7 && <4.8, http-media >=0.6 && <0.7, lens >=4.9 && <4.10, pandoc-types >=1.12 && <1.13, servant-docs >=0.3 && <4, unordered-containers >=0.2 && <0.3, text >=1.2 && <1.3, bytestring >=0.10 && <0.11
 
   -- Directories containing source files.
   hs-source-dirs:      src


### PR DESCRIPTION
This implies some imports that weren't needed before (`Data.Monoid` and `Control.Lens`) and taking content-types and "introductions" into account.

It would be nice to release the next _servant-pandoc_ under version _0.4_ too, if you don't mind.
