### PR TITLE
Sort endpoints before generating markup

### DIFF
--- a/src/Servant/Docs/Pandoc.hs
+++ b/src/Servant/Docs/Pandoc.hs
@@ -39,7 +39,7 @@ import Network.HTTP.Media (MediaType)
 import qualified Data.HashMap.Strict as HM
 import Data.Text (Text, unpack)
 import Data.Monoid ((<>), mempty, mconcat)
-import Data.List (intercalate)
+import Data.List (intercalate, sort)
 import Data.Foldable (foldMap)
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as B (unpack)
@@ -81,7 +81,7 @@ pandoc api = B.doc $ intros <> mconcat endpoints
         printIntro i =
           B.header 1 (B.str $ i ^. introTitle) <>
           foldMap (B.para . B.str) (i ^. introBody)
-        endpoints = map (uncurry printEndpoint) . HM.toList $ api ^. apiEndpoints
+        endpoints = map (uncurry printEndpoint) . sort . HM.toList $ api ^. apiEndpoints
 
         capturesStr :: [DocCapture] -> Blocks
         capturesStr [] = mempty


### PR DESCRIPTION
This makes the docs somewhat nicer to read (e.g. it groups endpoints that share a path together). servant-docs also does this before generating markdown.
