### PR TITLE
Alter cabal bounds to build on nightly-2015-07-23

### DIFF
--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -62,16 +62,12 @@ library
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.7 && <5
                      , http-media >=0.6 && <0.7
-                     , lens >=4.9 && <4.10
+                     , lens >=4.9 && <4.12
                      , pandoc-types >=1.12 && <1.13
                      , servant-docs >=0.4 && <0.5
                      , unordered-containers >=0.2 && <0.3
                      , text >=1.2 && <1.3
                      , bytestring >=0.10 && <0.11
-
-                     -- temporary workaround
-                     -- (see https://github.com/mpickering/servant-pandoc/issues/2 for details)
-                     , semigroupoids <4.5
 
   -- Directories containing source files.
   hs-source-dirs:      src


### PR DESCRIPTION
Bump the lens upper bound and remove the semigroups dependency.
