### PR TITLE
Bump dependencies

### DIFF
--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -63,10 +63,10 @@ library
 
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.7 && <5
-                     , http-media >=0.6 && <0.7
+                     , http-media >=0.6 && <0.8
                      , lens >=4.9 && <5
-                     , pandoc-types >=1.12 && <1.13
-                     , servant-docs >=0.4 && <0.5
+                     , pandoc-types >=1.12 && <1.18
+                     , servant-docs >=0.4 && <=0.10
                      , unordered-containers >=0.2 && <0.3
                      , text >=1.2 && <1.3
                      , bytestring >=0.10 && <0.11

--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -66,7 +66,7 @@ library
                      , http-media >=0.6 && <0.8
                      , lens >=4.9 && <5
                      , pandoc-types >=1.12 && <1.18
-                     , servant-docs >=0.4 && <=0.10
+                     , servant-docs >=0.4 && <0.11
                      , unordered-containers >=0.2 && <0.3
                      , text >=1.2 && <1.3
                      , bytestring >=0.10 && <0.11


### PR DESCRIPTION
This should probably not be merged until haskell-servant/servant#784 is fixed though (and the dependencies adjusted accordingly).

Once that's done, then this closes haskell-servant/servant#782.