### PR TITLE
Bump bounds, compile with ghc 9.4.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ cabal.sandbox.config
 cabal.project.local
 /*.ebal
 .dir-locals.el
+dist-newstyle/

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,4 @@
 packages: .
+
+allow-newer:
+  servant-docs:lens

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,0 @@
-packages: .
-
-allow-newer:
-  servant-docs:lens

--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -25,12 +25,12 @@ library
 
   build-depends:       base >=4.7 && <5
                      , http-media >=0.6 && <0.9
-                     , lens >=4.9 && <5
+                     , lens >=4.9 && <6
                      , pandoc-types >=1.22 && <2
-                     , servant-docs >= 0.11.1 && < 0.12
+                     , servant-docs >= 0.11.1 && < 0.13
                      , unordered-containers >=0.2 && <0.3
                      , text >=1.2 && <1.3
-                     , bytestring >=0.10 && <0.11
+                     , bytestring >=0.10 && <0.12
                      , string-conversions >= 0.1 && < 0.5
                      , case-insensitive >= 0.2 && < 1.3
 

--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -29,7 +29,7 @@ library
                      , pandoc-types >=1.22 && <2
                      , servant-docs >= 0.11.1 && < 0.13
                      , unordered-containers >=0.2 && <0.3
-                     , text >=1.2 && <1.3
+                     , text >=2 && <3
                      , bytestring >=0.10 && <0.12
                      , string-conversions >= 0.1 && < 0.5
                      , case-insensitive >= 0.2 && < 1.3

--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -26,7 +26,7 @@ library
   build-depends:       base >=4.7 && <5
                      , http-media >=0.6 && <0.9
                      , lens >=4.9 && <5
-                     , pandoc-types >=1.12 && <1.21
+                     , pandoc-types >=1.22 && <2
                      , servant-docs >= 0.11.1 && < 0.12
                      , unordered-containers >=0.2 && <0.3
                      , text >=1.2 && <1.3

--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -29,7 +29,7 @@ library
                      , pandoc-types >=1.22 && <2
                      , servant-docs >= 0.11.1 && < 0.13
                      , unordered-containers >=0.2 && <0.3
-                     , text >=2 && <3
+                     , text (>=1.2 && <1.3) || (>=2 && <3)
                      , bytestring >=0.10 && <0.12
                      , string-conversions >= 0.1 && < 0.5
                      , case-insensitive >= 0.2 && < 1.3

--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -26,7 +26,7 @@ library
   build-depends:       base >=4.7 && <5
                      , http-media >=0.6 && <0.9
                      , lens >=4.9 && <5
-                     , pandoc-types >=1.12 && <1.18
+                     , pandoc-types >=1.12 && <1.21
                      , servant-docs >= 0.11.1 && < 0.12
                      , unordered-containers >=0.2 && <0.3
                      , text >=1.2 && <1.3

--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -24,7 +24,7 @@ library
   other-extensions:    OverloadedStrings
 
   build-depends:       base >=4.7 && <5
-                     , http-media >=0.6 && <0.8
+                     , http-media >=0.6 && <0.9
                      , lens >=4.9 && <5
                      , pandoc-types >=1.12 && <1.18
                      , servant-docs >= 0.11.1 && < 0.12

--- a/src/Servant/Docs/Pandoc.hs
+++ b/src/Servant/Docs/Pandoc.hs
@@ -73,10 +73,11 @@ import Servant.Docs (API, Action, DocAuthentication, DocCapture, DocNote,
                      requestExamples, respBody, respStatus, respTypes, response,
                      responseExamples, rqbody, rqtypes)
 
-import           Control.Lens               (mapped, view, (%~), (^.))
+import           Control.Lens               (mapped, view, (%~), (^.), _1)
 import           Data.ByteString.Lazy       (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as B
-import           Data.CaseInsensitive       (foldedCase)
+import qualified Data.ByteString.Char8 as BSC
+import           Data.CaseInsensitive       (foldedCase, original)
 import           Data.Foldable              (fold)
 import qualified Data.HashMap.Strict        as HM
 import           Data.List                  (sort)
@@ -93,6 +94,9 @@ import           Text.Pandoc.Builder    (Blocks, Inlines)
 import qualified Text.Pandoc.Builder    as B
 import           Text.Pandoc.Definition (Pandoc)
 import           Text.Pandoc.JSON       (toJSONFilter)
+import Control.Lens.Combinators (toListOf)
+import Control.Lens (Each(..))
+import Control.Lens (to)
 
 --------------------------------------------------------------------------------
 
@@ -154,7 +158,7 @@ pandocWith renderOpts api = B.doc $ intros <> mconcat endpoints
       , notesStr    (action ^. notes)
       , authStr     (action ^. authInfo)
       , capturesStr (action ^. captures)
-      , headersStr  (action ^. headers)
+      , headersStr  (toListOf (headers . each . _1 . to (T.pack . BSC.unpack . original)) action)
       , paramsStr   (action ^. params)
       , rqbodyStrs  (action ^. rqtypes) (action ^. rqbody)
       , responseStr (action ^. response)

--- a/src/Servant/Docs/Pandoc.hs
+++ b/src/Servant/Docs/Pandoc.hs
@@ -73,7 +73,8 @@ import Servant.Docs (API, Action, DocAuthentication, DocCapture, DocNote,
                      requestExamples, respBody, respStatus, respTypes, response,
                      responseExamples, rqbody, rqtypes)
 
-import           Control.Lens               (mapped, view, (%~), (^.), _1)
+import           Control.Lens (Each (..), mapped, to, view, (%~), (^.), _1)
+import           Control.Lens.Combinators (toListOf)
 import           Data.ByteString.Lazy       (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as B
 import qualified Data.ByteString.Char8 as BSC
@@ -94,9 +95,6 @@ import           Text.Pandoc.Builder    (Blocks, Inlines)
 import qualified Text.Pandoc.Builder    as B
 import           Text.Pandoc.Definition (Pandoc)
 import           Text.Pandoc.JSON       (toJSONFilter)
-import Control.Lens.Combinators (toListOf)
-import Control.Lens (Each(..))
-import Control.Lens (to)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
I tested compilation with `ghc-9.4.5`, `ghc-9.2.7` and `ghc-8.10.7`:

```
$ cabal build all
Resolving dependencies...
Build profile: -w ghc-9.4.5 -O1
In order, the following will be built (use -v for more details):
 - servant-pandoc-0.5.0.0 (lib) (first run)
Configuring library for servant-pandoc-0.5.0.0..
Preprocessing library for servant-pandoc-0.5.0.0..
Building library for servant-pandoc-0.5.0.0..
[1 of 1] Compiling Servant.Docs.Pandoc

$ cabal build all
Resolving dependencies...
Build profile: -w ghc-9.2.7 -O1
In order, the following will be built (use -v for more details):
 - servant-pandoc-0.5.0.0 (lib) (first run)
Configuring library for servant-pandoc-0.5.0.0..
Preprocessing library for servant-pandoc-0.5.0.0..
Building library for servant-pandoc-0.5.0.0..
[1 of 1] Compiling Servant.Docs.Pandoc

$ cabal build all
Resolving dependencies...
Build profile: -w ghc-8.10.7 -O1
In order, the following will be built (use -v for more details):
 - servant-pandoc-0.5.0.0 (lib) (first run)
Configuring library for servant-pandoc-0.5.0.0..
Preprocessing library for servant-pandoc-0.5.0.0..
Building library for servant-pandoc-0.5.0.0..
[1 of 1] Compiling Servant.Docs.Pandoc
```